### PR TITLE
Fixes !mdn link from box-sizing to height

### DIFF
--- a/docs/layout/heights/index.html
+++ b/docs/layout/heights/index.html
@@ -201,7 +201,7 @@ Media Query Extensions:
   </div>
   <div class="mtxl">
     <h1 class="f4 ttu tracked semibold">Reference</h1>
-    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing" class="link semibold blue dim">MDN - Box Sizing</a>
+    <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/height" class="link semibold blue dim">MDN - Height</a>
   </div>
 </div>
       <section class="bg-dark-gray white ptl pbxl">


### PR DESCRIPTION
Found a typo in the `heights` doc page that referenced `box-sizing`.